### PR TITLE
Add links to the sub-module GitHub repositories

### DIFF
--- a/docs/shared/contribution_guidelines/metadata_instances.rst
+++ b/docs/shared/contribution_guidelines/metadata_instances.rst
@@ -2,3 +2,9 @@
 Metadata instances
 ##################
 
+If you would like to suggest a new entry in our `controlled vocabulary`_,
+please first check `here <https://github.com/openMetadataInitiative/openMINDS_instances/issues>`_ if someone else has already suggested it.
+If they have, please add your support to their issue,
+and if not then `create a new issue <https://github.com/openMetadataInitiative/openMINDS_instances/issues/new>`.
+
+.. _`controlled vocabulary`: https://openminds-documentation.readthedocs.io/en/latest/instance_libraries.html

--- a/docs/shared/contribution_guidelines/metadata_schemas.rst
+++ b/docs/shared/contribution_guidelines/metadata_schemas.rst
@@ -10,7 +10,7 @@ openMINDS syntax
 The openMINDS metadata schemas are first developed as templates and then automatically interpreted and extended with the centrally maintained openMINDS vocabulary to complete metadata schemas through the openMINDS pipeline. Both schema templates (``*.schema.tpl.json``) and complete schemas (``*.schema.omi.json``) are written in an openMINDS-specific syntax. This syntax is loosely based on JSON-Schema, but tailored to facilitate implementation, readability, and maintainability. The openMINDS syntax for templates, vocabulary and complete schemas is explained in the following.
 
 **********
-Essentials 
+Essentials
 **********
 The following code block sketches the most simple implementation of an openMINDS schema template.
 
@@ -44,3 +44,26 @@ Development guidelines
 #. Within a schema, only properties that can be expected for all respected real-world entities should be made required.
 #. If properties of a real-world entity contains potentially sensitive information (e.g., personal data), these properties should be specified in a separate schema.
 #. Schema properties should be consistently reduced to a minimum, meaning the reuse of a property name across schemas is highly recommended, if the definition of that property name remains the same.
+
+Current schemas
+###############
+
+- core_
+- SANDS_
+- controlledTerms_
+- computation_
+- specimenPrep_
+- ephys_
+- stimulation_
+- publication_
+
+The central repository that pulls everything together is at https://github.com/openMetadataInitiative/openMINDS.
+
+.. _core: https://github.com/openMetadataInitiative/openMINDS_core
+.. _SANDS: https://github.com/openMetadataInitiative/openMINDS_SANDS
+.. _controlledTerms: https://github.com/openMetadataInitiative/openMINDS_controlledTerms
+.. _computation: https://github.com/openMetadataInitiative/openMINDS_computation
+.. _specimenPrep: https://github.com/openMetadataInitiative/openMINDS_specimenPrep
+.. _ephys: https://github.com/openMetadataInitiative/openMINDS_ephys
+.. _stimulation: https://github.com/openMetadataInitiative/openMINDS_stimulation
+.. _publication: https://github.com/openMetadataInitiative/openMINDS_publication

--- a/docs/shared/contribution_guidelines/metadata_schemas.rst
+++ b/docs/shared/contribution_guidelines/metadata_schemas.rst
@@ -45,25 +45,7 @@ Development guidelines
 #. If properties of a real-world entity contains potentially sensitive information (e.g., personal data), these properties should be specified in a separate schema.
 #. Schema properties should be consistently reduced to a minimum, meaning the reuse of a property name across schemas is highly recommended, if the definition of that property name remains the same.
 
-Current schemas
-###############
+Schema contributions
+####################
 
-- core_
-- SANDS_
-- controlledTerms_
-- computation_
-- specimenPrep_
-- ephys_
-- stimulation_
-- publication_
-
-The central repository that pulls everything together is at https://github.com/openMetadataInitiative/openMINDS.
-
-.. _core: https://github.com/openMetadataInitiative/openMINDS_core
-.. _SANDS: https://github.com/openMetadataInitiative/openMINDS_SANDS
-.. _controlledTerms: https://github.com/openMetadataInitiative/openMINDS_controlledTerms
-.. _computation: https://github.com/openMetadataInitiative/openMINDS_computation
-.. _specimenPrep: https://github.com/openMetadataInitiative/openMINDS_specimenPrep
-.. _ephys: https://github.com/openMetadataInitiative/openMINDS_ephys
-.. _stimulation: https://github.com/openMetadataInitiative/openMINDS_stimulation
-.. _publication: https://github.com/openMetadataInitiative/openMINDS_publication
+For issues or contributions around the openMINDS metadata schemas, please raise first an issue on the `main openMINDS GitHub <https://github.com/openMetadataInitiative/openMINDS>`_.


### PR DESCRIPTION
Unless I missed them, there are no links from the contribution guidelines to the actual GitHub repositories.